### PR TITLE
feat: allow custom host to be passed at provider instantiation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,5 +33,5 @@ provider "posthog" {}
 
 ### Optional
 
-- `host` (String) The host for the PostHog API. Defaults to `app.posthog.com`
+- `host` (String) The host for the PostHog API. **Default** `app.posthog.com`
 - `token` (String) The token used to authenticate with PostHog.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,11 @@ There are several ways to provide the required token:
 * **Set the `token` argument in the provider configuration**. You can set the `token` argument in the provider configuration. Use an input variable for the token.
 * **Set the `POSTHOG_TOKEN` environment variable**. The provider can read the `POSTHOG_TOKEN` environment variable and the token stored there to authenticate.
 
+If your project is hosted outside of the PostHog Cloud US zone, you will need to pass the `host` argument to ensure the provider hits the correct API.
+
+* For the **EU Cloud** region, set `host` to `eu.posthog.com`
+* For **self-hosted** PostHog instances, set `host` to the URL of your instance
+
 ## Example Usage
 
 ```terraform
@@ -28,4 +33,5 @@ provider "posthog" {}
 
 ### Optional
 
+- `host` (String) The host for the PostHog API. Defaults to `app.posthog.com`
 - `token` (String) The token used to authenticate with PostHog.

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -10,12 +10,13 @@ import (
 
 type authedTransport struct {
 	token   string
+	host    string
 	wrapped http.RoundTripper
 }
 
 func (t *authedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.URL.Scheme = "https"
-	req.URL.Host = "app.posthog.com"
+	req.URL.Host = t.host
 	req.URL.Path = "/api" + req.URL.Path
 
 	req.Header.Set("Accept", "application/json")

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -50,7 +50,7 @@ func (p *PostHogProvider) Schema(ctx context.Context, req provider.SchemaRequest
 				Optional:            true,
 			},
 			"host": schema.StringAttribute{
-				MarkdownDescription: "The host for the PostHog API. Defaults to `" + defaultPosthogHost + "`",
+				MarkdownDescription: "The host for the PostHog API. **Default** `" + defaultPosthogHost + "`",
 				Optional:            true,
 			},
 		},

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -17,6 +17,11 @@ There are several ways to provide the required token:
 * **Set the `token` argument in the provider configuration**. You can set the `token` argument in the provider configuration. Use an input variable for the token.
 * **Set the `POSTHOG_TOKEN` environment variable**. The provider can read the `POSTHOG_TOKEN` environment variable and the token stored there to authenticate.
 
+If your project is hosted outside of the PostHog Cloud US zone, you will need to pass the `host` argument to ensure the provider hits the correct API.
+
+* For the **EU Cloud** region, set `host` to `eu.posthog.com`
+* For **self-hosted** PostHog instances, set `host` to the URL of your instance
+
 ## Example Usage
 
 {{ tffile "examples/provider/provider.tf" }}


### PR DESCRIPTION
PostHog instances can be created in the US or EU cloud, or can be self-hosted. As it stands, this provider is only compatible with the US cloud, as requests must be made to the appropriate API URL:

From the [API docs](https://posthog.com/docs/api)

> You must make API requests to the correct domain. On US Cloud, these are https://us.i.posthog.com for public endpoints and https://us.posthog.com for private ones. On EU Cloud, these are https://eu.i.posthog.com for public endpoints and https://eu.posthog.com for private ones. For self-hosted instances, use your self-hosted domain. Confirm yours by checking your PostHog instance URL.

This PR allows a different host to be passed when the provider is instantiated, enabling support for PostHog instances outside of the US cloud.

I have not added acceptance tests as the existing ones have hardcoded organisation IDs which I cannot replace whilst ensuring they pass CI. A new organisation and API key would be required that exist in the EU region to test this feature.