### PR TITLE
Deprecate community provider in favor of official PostHog provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Terraform PostHog Provider
+# Terraform PostHog Provider (Community)
+
+> **DEPRECATED:** This community provider is no longer maintained. PostHog now has an officially supported Terraform Provider available at [registry.terraform.io/providers/PostHog/posthog](https://registry.terraform.io/providers/PostHog/posthog/latest). Please migrate to the official provider for continued support and new features.
 
 A terraform provider for [posthog.com](https://posthog.com)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,9 @@
 page_title: "PostHog Provider"
 ---
 
-# PostHog Provider
+# PostHog Provider (Community) - DEPRECATED
+
+~> **DEPRECATED:** This community provider is no longer maintained. PostHog now has an [officially supported Terraform Provider](https://registry.terraform.io/providers/PostHog/posthog/latest). Please migrate to the official provider for continued support and new features.
 
 This provider is used to interact with the many resources supported by [PostHog](https://posthog.com).
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -8,6 +8,8 @@ description: |-
 
 # posthog_project (Resource)
 
+~> **DEPRECATED:** This community provider is no longer maintained. Please use the [official PostHog Terraform Provider](https://registry.terraform.io/providers/PostHog/posthog/latest) instead.
+
 PostHog project.
 
 ## Example Usage


### PR DESCRIPTION
## Summary
- Add deprecation notices to `README.md`, `docs/index.md`, and `docs/resources/project.md`
- Point users to the official [PostHog Terraform Provider](https://registry.terraform.io/providers/PostHog/posthog), with the [GitHub repository living here](https://github.com/PostHog/terraform-provider-posthog).

## Context
Thanks to @pksunkara for building and maintaining the community provider! Now that PostHog maintains an official Terraform Provider, this community provider is no longer needed.

If you'd like to get in touch, we'd love to send you some PostHog merch as a token of our appreciation! Feel free to reach out to me directly at `vasco<at>posthog.com`!